### PR TITLE
Fix array_unique to not filter 'constructor'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function array_unique(arr){
 
     for(i = 0; i < arr.length; i++){
         key = keyify(arr[i]);
-        if(!(key in seen)){
+        if(!seen.hasOwnProperty(key)){
             ret_arr.push(arr[i]);
             seen[key] = true;
         }


### PR DESCRIPTION
The previous solution would turn [1,2,1,'constructor'] to [1,2], which seems to be an erroneous behavior.